### PR TITLE
Feat api currency format

### DIFF
--- a/api/app/data_models.py
+++ b/api/app/data_models.py
@@ -30,7 +30,7 @@ class PredictionRequest(BaseModel):
 
 
 class PredictionResponse(BaseModel):
-    worldwide_gross: float
+    worldwide_gross: str
 
     class Config:
         extra = "forbid"

--- a/api/app/views.py
+++ b/api/app/views.py
@@ -5,7 +5,7 @@ from .app_utils import get_model, transform_to_dataframe
 MODEL = get_model()
 
 
-def get_prediction(request: PredictionRequest) -> float:
+def get_prediction(request: PredictionRequest) -> str:
     data_to_predict = transform_to_dataframe(request)
     prediction = MODEL.predict(data_to_predict)[0]
-    return max(0, prediction)
+    return '$ {:,.2f}'.format(max(0, prediction))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ def test_null_prediction():
         },
     )
     assert response.status_code == 200
-    assert response.json()["worldwide_gross"] == 0
+    assert response.json()["worldwide_gross"] == '$ 0.00'
 
 
 def test_random_prediction():
@@ -41,4 +41,4 @@ def test_random_prediction():
         },
     )
     assert response.status_code == 200
-    assert response.json()["worldwide_gross"] != 0
+    assert response.json()["worldwide_gross"] != '$ 0.00'


### PR DESCRIPTION
In this PR I'm adding a feature to represent the result from the API as a string in a more human-readable format: currency format.

Example:
Response before feature:
![image](https://user-images.githubusercontent.com/18086414/178164922-89135856-3837-4f2b-acdc-f330ae5f9ffb.png)

Response after feature:
![image](https://user-images.githubusercontent.com/18086414/178164798-e98c1cf0-afb0-4f9d-82c3-7b3e6b2cd372.png)